### PR TITLE
Update Timestamp.php

### DIFF
--- a/src/Carbon/Traits/Timestamp.php
+++ b/src/Carbon/Traits/Timestamp.php
@@ -25,6 +25,7 @@ trait Timestamp
      *
      * Timestamp input can be given as int, float or a string containing one or more numbers.
      */
+    #[\ReturnTypeWillChange]
     public static function createFromTimestamp(
         float|int|string $timestamp,
         DateTimeZone|string|int|null $timezone = null,


### PR DESCRIPTION
When using PHP 8.4, I get the following error: 

```
Deprecated: Return type of Carbon\Traits\Date::createFromTimestamp($timestamp, $tz = null) should either be compatible with DateTime::createFromTimestamp(int|float $timestamp): static, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in nesbot/carbon/src/Carbon/Traits/Timestamp.php on line 29
```

I am adding the annotation to resolve this issue.