### PR TITLE
Timestamp::createFromTimestamp() to use date_default_timezone_get()

### DIFF
--- a/src/Carbon/Traits/Timestamp.php
+++ b/src/Carbon/Traits/Timestamp.php
@@ -32,7 +32,7 @@ trait Timestamp
     ): static {
         $date = static::createFromTimestampUTC($timestamp);
 
-        return $timezone === null ? $date : $date->setTimezone($timezone);
+        return $timezone === null ? $date->setTimezone(date_default_timezone_get()) : $date->setTimezone($timezone);
     }
 
     /**


### PR DESCRIPTION
This Fixes #18 if accepted. It will eliminate the need to reintroduce `createFromTimestampCurrentTZ()` by updating the `createFromTimestamp()` to take advantage of `date_default_timezone_get()` by default. This allows the developer to:
- pass a timezone in as a paramter
- call `date_default_timezone_set()` to set the timezone
- returns the `UTC` by default if nothing else changes