### PR TITLE
Add `isNow()` method

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -2890,6 +2890,18 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
     public static function isMutable(): bool;
 
     /**
+     * Determines if the instance is now.
+     *
+     * @example
+     * ```
+     * Carbon::now()->isNow(); // true
+     * Carbon::now()->subHours(1)->isNow(); // false
+     * Carbon::now()->addHours(1)->isNow(); // false
+     * ```
+     */
+    public function isNow(): bool;
+
+    /**
      * Determines if the instance is now or in the future, ie. greater (after) than or equal to now.
      *
      * @example

--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -491,6 +491,21 @@ trait Comparison
     }
 
     /**
+     * Determines if the instance is now.
+     *
+     * @example
+     * ```
+     * Carbon::now()->isNow(); // true
+     * Carbon::now()->subHours(1)->isNow(); // false
+     * Carbon::now()->addHours(1)->isNow(); // false
+     * ```
+     */
+    public function isNow(): bool
+    {
+        return $this->equalTo($this->nowWithSameTz());
+    }
+
+    /**
      * Determines if the instance is a leap year.
      *
      * @example

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -270,6 +270,21 @@ class IsTest extends AbstractTestCase
         $this->assertTrue(Carbon::now()->isNowOrPast());
     }
 
+    public function testIsNowFalseInThePast()
+    {
+        $this->assertFalse(Carbon::now()->subSecond()->isNow());
+    }
+
+    public function testIsNowFalseInTheFuture()
+    {
+        $this->assertFalse(Carbon::now()->addSecond()->isNow());
+    }
+
+    public function testIsNowTrue()
+    {
+        $this->assertTrue(Carbon::now()->isNow());
+    }
+
     public function testIsLeapYearTrue()
     {
         $this->assertTrue(Carbon::createFromDate(2016, 1, 1)->isLeapYear());

--- a/tests/CarbonImmutable/IsTest.php
+++ b/tests/CarbonImmutable/IsTest.php
@@ -267,6 +267,21 @@ class IsTest extends AbstractTestCase
         $this->assertTrue(Carbon::now()->isNowOrPast());
     }
 
+    public function testIsNowFalseInThePast()
+    {
+        $this->assertFalse(Carbon::now()->subSecond()->isNow());
+    }
+
+    public function testIsNowFalseInTheFuture()
+    {
+        $this->assertFalse(Carbon::now()->addSecond()->isNow());
+    }
+
+    public function testIsNowTrue()
+    {
+        $this->assertTrue(Carbon::now()->isNow());
+    }
+
     public function testIsLeapYearTrue()
     {
         $this->assertTrue(Carbon::createFromDate(2016, 1, 1)->isLeapYear());


### PR DESCRIPTION
## Why
I added `isNowOrPast()` and `isNowOrFuture()` in #27. Since you can now basically use `<`, `>`, `<=`, and `>=` to compare to `now`, I thought I might as well try adding `==`.

## What
- Added the `isNow` method using `$this->equalTo($this->nowWithSameTz());`
- Added tests in both `tests/Carbon/IsTest.php` and `tests/CarbonImmutable/IsTest.php`

> [!NOTE]
> I don't love my wording of the docblock. `Determines if the instance is now.` doesn't sound quite right, but `Determines if the instance is now, ie. equal to now.` doesn't make sense either. Let me know if you want me to change this before merging.
