### PR TITLE
fix: add dynamic return type for `tz()`

### DIFF
--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -1836,6 +1836,8 @@ trait Date
 
     /**
      * Set the timezone or returns the timezone name if no arguments passed.
+     *
+     * @return ($value is null ? string : static)
      */
     public function tz(DateTimeZone|string|int|null $value = null): static|string
     {


### PR DESCRIPTION
This should stop phpstan from complaining about the return type.