### PR TITLE
Fix undefined constant self::DEFAULT_LOCALE error

### DIFF
--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -685,7 +685,7 @@ trait Creator
         string $format,
         string $time,
         $timezone = null,
-        ?string $locale = self::DEFAULT_LOCALE,
+        ?string $locale = CarbonInterface::DEFAULT_LOCALE,
         ?TranslatorInterface $translator = null
     ): ?self {
         $format = preg_replace_callback('/(?<!\\\\)(\\\\{2})*(LTS|LT|[Ll]{1,4})/', function ($match) use ($locale, $translator) {


### PR DESCRIPTION
This PR fixes the error related to the undefined constant self::DEFAULT_LOCALE by replacing it with CarbonInterface::DEFAULT_LOCALE from the Carbon library. This change aligns with the Carbon package’s constants usage and resolves the runtime exception.

After applying this fix, the application runs correctly without errors related to locale constants.

**Before changes:**
```php
  Undefined constant self::DEFAULT_LOCALE

  at vendor/nesbot/carbon/src/Carbon/Traits/Creator.php:688
    684▕     public static function createFromIsoFormat(
    685▕         string $format,
    686▕         string $time,
    687▕         $timezone = null,
  ➜ 688▕         ?string $locale = self::DEFAULT_LOCALE,
    689▕         ?TranslatorInterface $translator = null
    690▕     ): ?self {
    691▕         $format = preg_replace_callback('/(?<!\\\\)(\\\\{2})*(LTS|LT|[Ll]{1,4})/', function ($match) use ($locale, $translator) {
    692▕             [$code] = $match;

      +13 vendor frames 

`