### PR TITLE
Fix: isoFormat('MMMM') for sl_SI not working

### DIFF
--- a/src/Carbon/Lang/sl.php
+++ b/src/Carbon/Lang/sl.php
@@ -120,6 +120,7 @@ return [
         'sameElse' => 'L',
     ],
     'months' => ['januar', 'februar', 'marec', 'april', 'maj', 'junij', 'julij', 'avgust', 'september', 'oktober', 'november', 'december'],
+    'months_standalone' => ['januarja', 'februarja', 'marca', 'aprila', 'maja', 'junija', 'julija', 'avgusta', 'septembra', 'oktobra', 'novembra', 'decembra'],
     'months_short' => ['jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'avg', 'sep', 'okt', 'nov', 'dec'],
     'weekdays' => ['nedelja', 'ponedeljek', 'torek', 'sreda', 'četrtek', 'petek', 'sobota'],
     'weekdays_short' => ['ned', 'pon', 'tor', 'sre', 'čet', 'pet', 'sob'],


### PR DESCRIPTION
Lack of "months_standalone" translations for **Slovenian file.**

```
<?php
// Laravel Code for issue reproduction:
use Carbon\Carbon;
use Carbon\CarbonPeriod;

Carbon::setLocale('sl');
Carbon::setFallbackLocale('sl');
CarbonPeriod::setLocale('sl_SI');
setlocale(LC_TIME, 'sl_SI.UTF-8', 'sl_SI.utf8', 'sl', 'slovenian');

echo "Mistranslation (uses fallback locale): " . Carbon::now()->isoFormat('MMMM') . PHP_EOL;
echo "OK - Slovenian translation: " . Carbon::now()->subDays(2)->diffForHumans() . PHP_EOL;
echo "If you overwrite the locale - it will translate to Slovenian: " . Carbon::now()->locale('sl_SI')->isoFormat('MMMM') . PHP_EOL;
```