### PR TITLE
PHP 8.5 compatibility: Use instance method for getMockedTestNowClone

### DIFF
--- a/src/Carbon/Traits/Test.php
+++ b/src/Carbon/Traits/Test.php
@@ -142,7 +142,7 @@ trait Test
         $now = $clock instanceof Factory
             ? $clock->getTestNow()
             : $this->nowFromClock($timezone);
-        $testInstance = $now ?? self::getMockedTestNowClone($timezone);
+        $testInstance = $now ?? $this->getMockedTestNowClone($timezone);
 
         if (!$testInstance) {
             return;


### PR DESCRIPTION
From PHP 8.5 onwards, calling non-static methods statically will raise an error.