### PR TITLE
Test memory leak in resetMessages()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
         "phpmd": "phpmd src text /phpmd.xml",
         "phpmd-test": "phpmd tests text /tests/phpmd-test.xml",
         "phpstan": "phpstan analyse --configuration phpstan.neon",
-        "phpunit": "phpunit --verbose",
+        "phpunit": "phpunit",
         "style-check": [
             "@phpcs",
             "@phpstan",

--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -988,19 +988,43 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /** @see https://github.com/CarbonPHP/carbon/issues/57 */
-    public function testResetMessagesMemoryConsumption()
+    public function testResetMessagesMemoryConsumptionAbsolute()
     {
         Carbon::getTranslator()->resetMessages('en');
 
         $start = memory_get_usage();
 
-        for ($i = 0; $i < 100; $i++) {
+        for ($i = 0; $i < 1000; $i++) {
             Carbon::getTranslator()->resetMessages('en');
         }
 
         $consumedMemory = memory_get_usage() - $start;
 
         $this->assertLessThan(100_000, $consumedMemory);
+    }
+
+    /** @see https://github.com/CarbonPHP/carbon/issues/57 */
+    public function testResetMessagesMemoryConsumptionRelative()
+    {
+        $n = 1000;
+
+        $start = memory_get_usage();
+
+        for ($i = 0; $i < $n; $i++) {
+            Carbon::getTranslator()->resetMessages('en');
+        }
+
+        $consumedMemoryA = memory_get_usage() - $start;
+
+        $start = memory_get_usage();
+
+        for ($i = 0; $i < $n * 2; $i++) {
+            Carbon::getTranslator()->resetMessages('en');
+        }
+
+        $consumedMemoryB = memory_get_usage() - $start;
+
+        $this->assertGreaterThan(0.9, $consumedMemoryA / $consumedMemoryB);
     }
 
     #[TestWith(['мая', 'May'])]


### PR DESCRIPTION
Add test for https://github.com/CarbonPHP/carbon/issues/57

New test fails because "B is roughly twice A".

Is the test good enough?

Additional:
- `phpunit` has no `--verbose` parameter since version 10