### PR TITLE
Don't clone when casting from immutable to immutable

### DIFF
--- a/src/Carbon/Traits/Mutability.php
+++ b/src/Carbon/Traits/Mutability.php
@@ -43,27 +43,22 @@ trait Mutability
 
     /**
      * Return a mutable copy of the instance.
-     *
-     * @return Carbon
      */
-    public function toMutable()
+    public function toMutable(): Carbon
     {
-        /** @var Carbon $date */
-        $date = $this->cast(Carbon::class);
-
-        return $date;
+        return $this->cast(Carbon::class);
     }
 
     /**
-     * Return a immutable copy of the instance.
-     *
-     * @return CarbonImmutable
+     * Return an immutable copy of the instance.
      */
-    public function toImmutable()
+    public function toImmutable(): CarbonImmutable
     {
-        /** @var CarbonImmutable $date */
-        $date = $this->cast(CarbonImmutable::class);
+        // Immutable objects are fine as is (uncloned)
+        if ($this::class === CarbonImmutable::class) {
+            return $this;
+        }
 
-        return $date;
+        return $this->cast(CarbonImmutable::class);
     }
 }

--- a/tests/CarbonImmutable/CreateTest.php
+++ b/tests/CarbonImmutable/CreateTest.php
@@ -328,4 +328,16 @@ class CreateTest extends AbstractTestCase
 
         $this->assertSame('2018-07-24 08:34', $date->format('Y-m-d H:i'));
     }
+
+    public function testStartOfTime()
+    {
+        $this->assertTrue(Carbon::startOfTime()->isStartOfTime());
+        $this->assertTrue(Carbon::startOfTime()->toImmutable()->isStartOfTime());
+    }
+
+    public function testEndOfTime()
+    {
+        $this->assertTrue(Carbon::endOfTime()->isEndOfTime());
+        $this->assertTrue(Carbon::endOfTime()->toImmutable()->isEndOfTime());
+    }
 }

--- a/tests/CarbonImmutable/InstanceTest.php
+++ b/tests/CarbonImmutable/InstanceTest.php
@@ -107,7 +107,7 @@ class InstanceTest extends AbstractTestCase
         $copy = $carbon->toImmutable();
 
         $this->assertEquals($copy, $carbon);
-        $this->assertNotSame($copy, $carbon);
+        $this->assertSame($copy, $carbon);
         $this->assertSame('en_CA', $copy->locale());
         $this->assertInstanceOf(CarbonImmutable::class, $copy);
         $this->assertTrue($copy->isImmutable());


### PR DESCRIPTION
If current object class already is exactly `Carbon\CarbonImmutable` then we can skip the `cast()` call when doing 
`->toImmutable()` on it.

Fix https://github.com/briannesbitt/Carbon/issues/3287