### PR TITLE
Implement withNegatives option to CarbonInterval::spec()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,7 @@
         "phpdoc": "php phpdoc.php",
         "phpmd": "phpmd src text /phpmd.xml",
         "phpmd-test": "phpmd tests text /tests/phpmd-test.xml",
-        "phpstan": "phpstan analyse --configuration phpstan.neon",
+        "phpstan": "phpstan analyse --configuration phpstan.neon --memory-limit 1024M",
         "phpunit": "phpunit --verbose",
         "style-check": [
             "@phpcs",

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -2544,11 +2544,10 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface, U
 
         $seconds = $withNegatives ? $interval->s : abs($interval->s);
 
-        if ($microseconds && $interval->f > 0) {
-            $seconds = \sprintf('%d.%06d', $seconds, abs($interval->f) * 1000000);
-        } elseif ($withNegatives && $interval->f !== 0.0) {
-            $seconds += $interval->f;
-            $seconds = number_format($seconds, 6, '.', '');
+        if ($microseconds && $interval->f !== 0.0) {
+            $seconds = $withNegatives
+                ? number_format($seconds + $interval->f, 6, '.', '')
+                : \sprintf('%d.%06d', $seconds, abs($interval->f) * 1000000);
         }
 
         $time = array_filter([

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -2517,45 +2517,55 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface, U
      *
      * @return string
      */
-    public static function getDateIntervalSpec(DateInterval $interval, bool $microseconds = false, array $skip = []): string
-    {
+    public static function getDateIntervalSpec(
+        DateInterval $interval,
+        bool $microseconds = false,
+        array $skip = [],
+        bool $withNegatives = false,
+    ): string {
         $date = array_filter([
-            static::PERIOD_YEARS => abs($interval->y),
-            static::PERIOD_MONTHS => abs($interval->m),
-            static::PERIOD_DAYS => abs($interval->d),
+            static::PERIOD_YEARS => $withNegatives ? $interval->y : abs($interval->y),
+            static::PERIOD_MONTHS => $withNegatives ? $interval->m : abs($interval->m),
+            static::PERIOD_DAYS => $withNegatives ? $interval->d : abs($interval->d),
         ]);
 
         $skip = array_map([Unit::class, 'toNameIfUnit'], $skip);
+        $days = abs((int) $interval->days);
 
         if (
-            $interval->days >= CarbonInterface::DAYS_PER_WEEK * CarbonInterface::WEEKS_PER_MONTH &&
+            $days >= CarbonInterface::DAYS_PER_WEEK * CarbonInterface::WEEKS_PER_MONTH &&
             (!isset($date[static::PERIOD_YEARS]) || \count(array_intersect(['y', 'year', 'years'], $skip))) &&
             (!isset($date[static::PERIOD_MONTHS]) || \count(array_intersect(['m', 'month', 'months'], $skip)))
         ) {
             $date = [
-                static::PERIOD_DAYS => abs($interval->days),
+                static::PERIOD_DAYS => $withNegatives ? $interval->days : $days,
             ];
         }
 
-        $seconds = abs($interval->s);
+        $seconds = $withNegatives ? $interval->s : abs($interval->s);
+
         if ($microseconds && $interval->f > 0) {
             $seconds = \sprintf('%d.%06d', $seconds, abs($interval->f) * 1000000);
+        } elseif ($withNegatives && $interval->f !== 0.0) {
+            $seconds += $interval->f;
+            $seconds = number_format($seconds, 6, '.', '');
         }
 
         $time = array_filter([
-            static::PERIOD_HOURS => abs($interval->h),
-            static::PERIOD_MINUTES => abs($interval->i),
+            static::PERIOD_HOURS => $withNegatives ? $interval->h : abs($interval->h),
+            static::PERIOD_MINUTES => $withNegatives ? $interval->i : abs($interval->i),
             static::PERIOD_SECONDS => $seconds,
         ]);
 
-        $specString = static::PERIOD_PREFIX;
+        $specString = ($withNegatives && $interval->invert ? '-' : '').static::PERIOD_PREFIX;
 
         foreach ($date as $key => $value) {
-            $specString .= $value.$key;
+            $specString .= ($withNegatives && $interval->invert ? '-' : '').$value.$key;
         }
 
         if (\count($time) > 0) {
             $specString .= static::PERIOD_TIME_PREFIX;
+
             foreach ($time as $key => $value) {
                 $specString .= $value.$key;
             }
@@ -2569,9 +2579,9 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface, U
      *
      * @return string
      */
-    public function spec(bool $microseconds = false): string
+    public function spec(bool $microseconds = false, bool $withNegatives = false): string
     {
-        return static::getDateIntervalSpec($this, $microseconds);
+        return static::getDateIntervalSpec($this, $microseconds, [], $withNegatives);
     }
 
     /**

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -437,6 +437,7 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface, U
 
         $spec = $years;
         $isStringSpec = (\is_string($spec) && !preg_match('/^[\d.]/', $spec));
+        $inverted = false;
 
         if (!$isStringSpec || (float) $years) {
             $spec = static::PERIOD_PREFIX;
@@ -463,8 +464,17 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface, U
             }
         }
 
+        if ($isStringSpec && str_starts_with($spec, '-')) {
+            $inverted = true;
+            $spec = substr($spec, 1);
+        }
+
         try {
             parent::__construct($spec);
+
+            if ($inverted) {
+                $this->invert = 1;
+            }
         } catch (Throwable $exception) {
             try {
                 parent::__construct('PT0S');
@@ -548,8 +558,17 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface, U
         }
 
         foreach (['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds'] as $unit) {
-            if ($$unit < 0) {
-                $this->set($unit, $$unit);
+            $value = $$unit;
+
+            if (
+                (
+                    \is_int($value)
+                    || \is_float($value)
+                    || (\is_string($value) && preg_match('/^[\d.-]+$/', $value))
+                )
+                && $value < 0
+            ) {
+                $this->set($unit, $value);
             }
         }
     }

--- a/tests/CarbonInterval/ConstructTest.php
+++ b/tests/CarbonInterval/ConstructTest.php
@@ -35,6 +35,7 @@ class ConstructTest extends AbstractTestCase
         $this->assertInstanceOf(DateInterval::class, $ci);
         $this->assertSame('PT0S', $ci->spec());
         $ci = new CarbonInterval('P1Y2M3D');
+        $this->assertSame(0, $ci->invert);
         $this->assertSame('P1Y2M3D', $ci->spec());
         $ci = CarbonInterval::create('PT0S');
         $this->assertSame('PT0S', $ci->spec());
@@ -48,6 +49,21 @@ class ConstructTest extends AbstractTestCase
         $this->assertSame('PT9H85M', $ci->spec());
         $ci = CarbonInterval::create('PT1999999999999.5H+85M');
         $this->assertSame('PT1999999999999H115M', $ci->spec());
+    }
+
+    public function testConstructWithNegativeValues(): void
+    {
+        $ci = CarbonInterval::create('-P1Y2M3D');
+        $this->assertSame('P1Y2M3D', $ci->spec());
+        $this->assertSame(1, $ci->invert);
+
+        $ci = CarbonInterval::create('P1Y-2M3DT-1H30M');
+        $this->assertSame(1, $ci->y);
+        $this->assertSame(-2, $ci->m);
+        $this->assertSame(3, $ci->d);
+        $this->assertSame(-1, $ci->hours);
+        $this->assertSame(30, $ci->minutes);
+        $this->assertSame(0, $ci->invert);
     }
 
     public function testConstructWithDateInterval()

--- a/tests/CarbonInterval/SpecTest.php
+++ b/tests/CarbonInterval/SpecTest.php
@@ -105,6 +105,7 @@ class SpecTest extends AbstractTestCase
 
     public function testSpecWithNegatives()
     {
+        /** @var CarbonInterval $ci */
         $ci = CarbonInterval::createFromDateString('-1 hour');
         $this->assertSame('PT1H', $ci->spec());
         $this->assertSame('PT-1H', $ci->spec(withNegatives: true));
@@ -113,6 +114,7 @@ class SpecTest extends AbstractTestCase
         $this->assertSame('PT1H', $ci->spec());
         $this->assertSame('-PT-1H', $ci->spec(withNegatives: true));
 
+        /** @var CarbonInterval $ci */
         $ci = CarbonInterval::createFromDateString('1 hour')->invert();
         $this->assertSame('PT1H', $ci->spec());
         $this->assertSame('-PT1H', $ci->spec(withNegatives: true));

--- a/tests/CarbonInterval/SpecTest.php
+++ b/tests/CarbonInterval/SpecTest.php
@@ -102,4 +102,19 @@ class SpecTest extends AbstractTestCase
         $ci = new CarbonInterval(1, 2, 0, 3, 4, 5, 6);
         $this->assertEquals($ci->optimize(), CarbonInterval::instance(new DateInterval($ci->spec()))->optimize());
     }
+
+    public function testSpecWithNegatives()
+    {
+        $ci = CarbonInterval::createFromDateString('-1 hour');
+        $this->assertSame('PT1H', $ci->spec());
+        $this->assertSame('PT-1H', $ci->spec(withNegatives: true));
+
+        $ci->invert();
+        $this->assertSame('PT1H', $ci->spec());
+        $this->assertSame('-PT-1H', $ci->spec(withNegatives: true));
+
+        $ci = CarbonInterval::createFromDateString('1 hour')->invert();
+        $this->assertSame('PT1H', $ci->spec());
+        $this->assertSame('-PT1H', $ci->spec(withNegatives: true));
+    }
 }

--- a/tests/CarbonInterval/SpecTest.php
+++ b/tests/CarbonInterval/SpecTest.php
@@ -115,8 +115,16 @@ class SpecTest extends AbstractTestCase
         $this->assertSame('-PT-1H', $ci->spec(withNegatives: true));
 
         /** @var CarbonInterval $ci */
-        $ci = CarbonInterval::createFromDateString('1 hour')->invert();
+        $ci = CarbonInterval::createFromDateString('1 hour');
+        $ci->invert();
         $this->assertSame('PT1H', $ci->spec());
         $this->assertSame('-PT1H', $ci->spec(withNegatives: true));
+
+        /** @var CarbonInterval $ci */
+        $ci = CarbonInterval::createFromDateString('-15 second -321654 microseconds');
+        $this->assertSame('PT15S', $ci->spec());
+        $this->assertSame('PT-15S', $ci->spec(withNegatives: true));
+        $this->assertSame('PT15.321654S', $ci->spec(microseconds: true));
+        $this->assertSame('PT-15.321654S', $ci->spec(microseconds: true, withNegatives: true));
     }
 }


### PR DESCRIPTION
- Implement `withNegatives` option to `CarbonInterval::spec()`
- Construct interval from specs containing minus signs at the beginning or before numbers

Resolves https://github.com/briannesbitt/Carbon/issues/3256