### PR TITLE
Simplify setTestNow

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -3786,11 +3786,8 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable, DiffOptio
      *   - When the string "now" is passed to the constructor or parse(), ex. new Carbon('now')
      *   - When a string containing the desired time is passed to Carbon::parse().
      *
-     * If you pass a string, only the moment is mocked, the timezone will still be the one passed
+     * Only the moment is mocked with setTestNow(), the timezone will still be the one passed
      * as parameter of date_default_timezone_get() as a fallback (see setTestNowAndTimezone()).
-     *
-     * If you pass a date object, the timezone of it will override date_default_timezone_get(),
-     * to avoid this behavior, use setTestNowWithDefaultTimezone() instead.
      *
      * To clear the test instance call this method using the default
      * parameter of null.
@@ -3821,27 +3818,6 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable, DiffOptio
      * @param DateTimeInterface|Closure|static|string|false|null $testNow real or mock Carbon instance
      */
     public static function setTestNowAndTimezone($testNow = null, $timezone = null): void;
-
-    /**
-     * Set a Carbon instance (real or mock) to be returned when a "now"
-     * instance is created. The provided instance will be returned
-     * specifically under the following conditions:
-     *   - A call to the static now() method, ex. Carbon::now()
-     *   - When a null (or blank string) is passed to the constructor or parse(), ex. new Carbon(null)
-     *   - When the string "now" is passed to the constructor or parse(), ex. new Carbon('now')
-     *   - When a string containing the desired time is passed to Carbon::parse().
-     *
-     * Only the moment is mocked with setTestNow(), the timezone will still be the one passed
-     * as parameter of date_default_timezone_get() as a fallback (see setTestNowAndTimezone()).
-     *
-     * To clear the test instance call this method using the default
-     * parameter of null.
-     *
-     * /!\ Use this method for unit tests only.
-     *
-     * @param DateTimeInterface|Closure|static|string|false|null $testNow real or mock Carbon instance
-     */
-    public static function setTestNowWithDefaultTimezone(mixed $testNow = null): void;
 
     /**
      * Resets the current time of the DateTime object to a different time.

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -1154,8 +1154,8 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface, U
      */
     public static function diff($start, $end = null, bool $absolute = false, array $skip = []): static
     {
-        $start = $start instanceof CarbonInterface ? $start : Carbon::make($start);
-        $end = $end instanceof CarbonInterface ? $end : Carbon::make($end);
+        $start = self::carbonOrMake($start);
+        $end = self::carbonOrMake($end);
         $rawInterval = $start->diffAsDateInterval($end, $absolute);
         $interval = static::instance($rawInterval, $skip);
 
@@ -3580,6 +3580,13 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface, U
                 // Drop unknown settings
                 return $this;
         }
+    }
+
+    private static function carbonOrMake(mixed $dateTime): CarbonInterface
+    {
+        return $dateTime instanceof CarbonInterface
+            ? $dateTime
+            : Carbon::make($dateTime);
     }
 
     private static function incrementUnit(DateInterval $instance, string $unit, int $value): void

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -2329,11 +2329,7 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
                     'options' => $this->setOptions(...),
                     'recurrences' => $this->setRecurrences(...),
                     'current' => function (mixed $current): void {
-                        if (!($current instanceof CarbonInterface)) {
-                            $current = $this->resolveCarbon($current);
-                        }
-
-                        $this->carbonCurrent = $current;
+                        $this->carbonCurrent = $this->carbonOrResolve($current);
                     },
                     'start' => 'startDate',
                     'interval' => $this->setDateInterval(...),
@@ -2629,6 +2625,13 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
         return $period instanceof DatePeriod
             ? static::instance($period)
             : static::create($period, ...$arguments);
+    }
+
+    private function carbonOrResolve(mixed $dateTime): CarbonInterface
+    {
+        return $dateTime instanceof CarbonInterface
+            ? $dateTime
+            : $this->resolveCarbon($dateTime);
     }
 
     private function orderCouple($first, $second): array

--- a/src/Carbon/Factory.php
+++ b/src/Carbon/Factory.php
@@ -561,11 +561,8 @@ class Factory
      *   - When the string "now" is passed to the constructor or parse(), ex. new Carbon('now')
      *   - When a string containing the desired time is passed to Carbon::parse().
      *
-     * If you pass a string, only the moment is mocked, the timezone will still be the one passed
+     * Only the moment is mocked with setTestNow(), the timezone will still be the one passed
      * as parameter of date_default_timezone_get() as a fallback (see setTestNowAndTimezone()).
-     *
-     * If you pass a date object, the timezone of it will override date_default_timezone_get(),
-     * to avoid this behavior, use setTestNowWithDefaultTimezone() instead or useDefaultTimezone: true.
      *
      * To clear the test instance call this method using the default
      * parameter of null.

--- a/src/Carbon/Factory.php
+++ b/src/Carbon/Factory.php
@@ -157,11 +157,6 @@ class Factory
     protected bool $useTimezoneFromTestNow = false;
 
     /**
-     * Is true when test-now is generated with date_default_timezone_get() as timezone.
-     */
-    protected bool $useDefaultTimezone = false;
-
-    /**
      * Default translator.
      */
     protected TranslatorInterface $translator;
@@ -579,48 +574,12 @@ class Factory
      *
      * @param DateTimeInterface|Closure|static|string|false|null $testNow real or mock Carbon instance
      */
-    public function setTestNow(mixed $testNow = null, bool $useDefaultTimezone = false): void
+    public function setTestNow(mixed $testNow = null): void
     {
-        if (
-            !$useDefaultTimezone
-            && $testNow instanceof DateTimeInterface
-            && $testNow->getTimezone()->getName() !== date_default_timezone_get()
-        ) {
-            @trigger_error(
-                "Since nesbot/carbon 3.12.0, it's deprecated to call setTestNow() with date object ".
-                "having a timezone different from date_default_timezone_get().\n".
-                'You can also now call setTestNowWithDefaultTimezone() to use a date while '.
-                'continuing to use the default timezone, or setTestNowAndTimezone() to set both '.
-                'date and timezone.',
-                \E_USER_DEPRECATED,
-            );
-        }
-
-        $this->applyTestNow($testNow, $useDefaultTimezone);
-    }
-
-    /**
-     * Set a Carbon instance (real or mock) to be returned when a "now"
-     * instance is created. The provided instance will be returned
-     * specifically under the following conditions:
-     *   - A call to the static now() method, ex. Carbon::now()
-     *   - When a null (or blank string) is passed to the constructor or parse(), ex. new Carbon(null)
-     *   - When the string "now" is passed to the constructor or parse(), ex. new Carbon('now')
-     *   - When a string containing the desired time is passed to Carbon::parse().
-     *
-     * Only the moment is mocked with setTestNow(), the timezone will still be the one passed
-     * as parameter of date_default_timezone_get() as a fallback (see setTestNowAndTimezone()).
-     *
-     * To clear the test instance call this method using the default
-     * parameter of null.
-     *
-     * /!\ Use this method for unit tests only.
-     *
-     * @param DateTimeInterface|Closure|static|string|false|null $testNow real or mock Carbon instance
-     */
-    public function setTestNowWithDefaultTimezone(mixed $testNow = null): void
-    {
-        $this->applyTestNow($testNow, true);
+        $this->useTimezoneFromTestNow = false;
+        $this->testNow = $testNow instanceof Closure
+            ? $testNow
+            : $this->make($testNow);
     }
 
     /**
@@ -654,8 +613,7 @@ class Factory
             $this->setDefaultTimezone($testNow->getTimezone()->getName(), $testNow);
         }
 
-        $this->applyTestNow($testNow, false);
-        $this->useDefaultTimezone = false;
+        $this->setTestNow($testNow);
         $this->useTimezoneFromTestNow = ($timezone === null && $testNow instanceof Closure);
 
         if (!$useDateInstanceTimezone) {
@@ -685,12 +643,12 @@ class Factory
     public function withTestNow(mixed $testNow, callable $callback): mixed
     {
         $previousTestNow = $this->getTestNow();
-        $this->applyTestNow($testNow, false);
+        $this->setTestNow($testNow);
 
         try {
             $result = $callback();
         } finally {
-            $this->applyTestNow($previousTestNow, false);
+            $this->setTestNow($previousTestNow);
         }
 
         return $result;
@@ -739,16 +697,14 @@ class Factory
             }
 
             if (!($testNow instanceof CarbonInterface)) {
-                $timezone ??= match (true) {
-                    $this->useDefaultTimezone => new CarbonTimeZone(date_default_timezone_get()),
-                    $this->useTimezoneFromTestNow => $testNow->getTimezone(),
-                    default => null,
-                };
+                $timezone ??= $this->useTimezoneFromTestNow
+                    ? $testNow->getTimezone()
+                    : new CarbonTimeZone(date_default_timezone_get());
                 $testNow = $this->__call('instance', [$testNow, $timezone]);
             }
         }
 
-        if ($timezone === null && $this->useDefaultTimezone) {
+        if ($testNow !== null && $timezone === null) {
             if ($testNow instanceof DateTime) {
                 $testNow = clone $testNow;
             }
@@ -902,14 +858,5 @@ class Factory
                 $previous
             );
         }
-    }
-
-    private function applyTestNow(mixed $testNow, bool $useDefaultTimezone): void
-    {
-        $this->useTimezoneFromTestNow = false;
-        $this->useDefaultTimezone = $useDefaultTimezone;
-        $this->testNow = $testNow instanceof Closure
-            ? $testNow
-            : $this->make($testNow);
     }
 }

--- a/src/Carbon/Traits/IntervalStep.php
+++ b/src/Carbon/Traits/IntervalStep.php
@@ -65,8 +65,7 @@ trait IntervalStep
      */
     public function convertDate(DateTimeInterface $dateTime, bool $negated = false): CarbonInterface
     {
-        /** @var CarbonInterface $carbonDate */
-        $carbonDate = $dateTime instanceof CarbonInterface ? $dateTime : $this->resolveCarbon($dateTime);
+        $carbonDate = $this->carbonOrResolve($dateTime);
 
         if ($this->step) {
             $carbonDate = Callback::parameter($this->step, $carbonDate->avoidMutation());
@@ -91,6 +90,13 @@ trait IntervalStep
         }
 
         return Carbon::instance($dateTime);
+    }
+
+    private function carbonOrResolve(mixed $dateTime): CarbonInterface
+    {
+        return $dateTime instanceof CarbonInterface
+            ? $dateTime
+            : $this->resolveCarbon($dateTime);
     }
 
     private function checkNoStepIsDefined(string $method): void

--- a/src/Carbon/Traits/Test.php
+++ b/src/Carbon/Traits/Test.php
@@ -49,7 +49,7 @@ trait Test
      */
     public static function setTestNow(mixed $testNow = null): void
     {
-        FactoryImmutable::getDefaultInstance()->setTestNow($testNow, false);
+        FactoryImmutable::getDefaultInstance()->setTestNow($testNow);
     }
 
     /**

--- a/src/Carbon/Traits/Test.php
+++ b/src/Carbon/Traits/Test.php
@@ -37,11 +37,8 @@ trait Test
      *   - When the string "now" is passed to the constructor or parse(), ex. new Carbon('now')
      *   - When a string containing the desired time is passed to Carbon::parse().
      *
-     * If you pass a string, only the moment is mocked, the timezone will still be the one passed
+     * Only the moment is mocked with setTestNow(), the timezone will still be the one passed
      * as parameter of date_default_timezone_get() as a fallback (see setTestNowAndTimezone()).
-     *
-     * If you pass a date object, the timezone of it will override date_default_timezone_get(),
-     * to avoid this behavior, use setTestNowWithDefaultTimezone() instead.
      *
      * To clear the test instance call this method using the default
      * parameter of null.
@@ -53,30 +50,6 @@ trait Test
     public static function setTestNow(mixed $testNow = null): void
     {
         FactoryImmutable::getDefaultInstance()->setTestNow($testNow, false);
-    }
-
-    /**
-     * Set a Carbon instance (real or mock) to be returned when a "now"
-     * instance is created. The provided instance will be returned
-     * specifically under the following conditions:
-     *   - A call to the static now() method, ex. Carbon::now()
-     *   - When a null (or blank string) is passed to the constructor or parse(), ex. new Carbon(null)
-     *   - When the string "now" is passed to the constructor or parse(), ex. new Carbon('now')
-     *   - When a string containing the desired time is passed to Carbon::parse().
-     *
-     * Only the moment is mocked with setTestNow(), the timezone will still be the one passed
-     * as parameter of date_default_timezone_get() as a fallback (see setTestNowAndTimezone()).
-     *
-     * To clear the test instance call this method using the default
-     * parameter of null.
-     *
-     * /!\ Use this method for unit tests only.
-     *
-     * @param DateTimeInterface|Closure|static|string|false|null $testNow real or mock Carbon instance
-     */
-    public static function setTestNowWithDefaultTimezone(mixed $testNow = null): void
-    {
-        FactoryImmutable::getDefaultInstance()->setTestNow($testNow, true);
     }
 
     /**

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -456,7 +456,7 @@ class TestingAidsTest extends AbstractTestCase
         Carbon::setTestNow();
         date_default_timezone_set('UTC');
 
-        Carbon::setTestNowWithDefaultTimezone(
+        Carbon::setTestNow(
             Carbon::create(2025, 9, 18, 15, 34, timezone: new DateTimeZone('Europe/London')),
         );
 
@@ -466,6 +466,17 @@ class TestingAidsTest extends AbstractTestCase
         );
         $this->assertSame(
             '15:13 UTC',
+            Carbon::createFromFormat('Y-m-d H:i:s', '2025-09-18 15:13:00')->format('H:i e'),
+        );
+
+        date_default_timezone_set('America/Toronto');
+
+        $this->assertSame(
+            '10:34 America/Toronto',
+            Carbon::now()->format('H:i e'),
+        );
+        $this->assertSame(
+            '15:13 America/Toronto',
             Carbon::createFromFormat('Y-m-d H:i:s', '2025-09-18 15:13:00')->format('H:i e'),
         );
 
@@ -494,7 +505,7 @@ class TestingAidsTest extends AbstractTestCase
         );
 
         $this->assertSame(
-            '15:13 Europe/London',
+            '15:13 America/Edmonton',
             Carbon::createFromFormat('Y-m-d H:i:s', '2025-09-18 15:13:00')->format('H:i e'),
         );
 
@@ -507,7 +518,7 @@ class TestingAidsTest extends AbstractTestCase
             Carbon::createFromFormat('Y-m-d H:i:s', '2025-09-18 15:13:00')->format('H:i e'),
         );
 
-        Carbon::setTestNow(
+        Carbon::setTestNowAndTimezone(
             new DateTime('2025-09-18 14:00:00', new DateTimeZone('America/New_York')),
         );
 
@@ -517,20 +528,24 @@ class TestingAidsTest extends AbstractTestCase
         );
 
         $factory = new Factory();
-        $factory->setTestNow(
-            new DateTime('2025-09-18 14:00:00', new DateTimeZone('Pacific/Auckland')),
-        );
+        $date = new DateTime('2025-09-18 14:00:00', new DateTimeZone('Pacific/Auckland'));
+        $factory->setTestNow($date);
 
         $this->assertSame(
-            '15:13 Pacific/Auckland',
+            '15:13 America/New_York',
             $factory->createFromFormat('Y-m-d H:i:s', '2025-09-18 15:13:00')->format('H:i e'),
+        );
+        $this->assertSame(
+            '14:00 Pacific/Auckland',
+            $date->format('H:i e'),
+            'Original date should not be mutated',
         );
 
         $date = new DateTime('2025-09-18 14:00:00', new DateTimeZone('Pacific/Auckland'));
-        $factory->setTestNowWithDefaultTimezone($date);
+        $factory->setTestNowAndTimezone($date);
 
         $this->assertSame(
-            '15:13 America/Edmonton',
+            '15:13 Pacific/Auckland',
             $factory->createFromFormat('Y-m-d H:i:s', '2025-09-18 15:13:00')->format('H:i e'),
         );
         $this->assertSame(
@@ -545,7 +560,7 @@ class TestingAidsTest extends AbstractTestCase
         Carbon::setTestNow();
         date_default_timezone_set('UTC');
 
-        Carbon::setTestNowWithDefaultTimezone(
+        Carbon::setTestNow(
             '2025-10-24T00:30:00+0200',
         );
 
@@ -574,7 +589,7 @@ class TestingAidsTest extends AbstractTestCase
         );
 
         $this->assertSame(
-            '15:13 +02:00',
+            '15:13 America/Edmonton',
             Carbon::createFromFormat('Y-m-d H:i:s', '2025-09-18 15:13:00')->format('H:i e'),
         );
 
@@ -582,14 +597,21 @@ class TestingAidsTest extends AbstractTestCase
         $factory->setTestNow('2025-09-18 14:00:00 Pacific/Auckland');
 
         $this->assertSame(
-            '15:13 Pacific/Auckland',
+            '15:13 America/Edmonton',
             $factory->createFromFormat('Y-m-d H:i:s', '2025-09-18 15:13:00')->format('H:i e'),
         );
 
-        $factory->setTestNowWithDefaultTimezone('2025-09-18 14:00:00 Pacific/Auckland');
+        $factory->setTestNowAndTimezone('2025-09-18 14:00:00 Pacific/Auckland');
 
         $this->assertSame(
             '15:13 America/Edmonton',
+            $factory->createFromFormat('Y-m-d H:i:s', '2025-09-18 15:13:00')->format('H:i e'),
+        );
+
+        $factory->setTestNowAndTimezone('2025-09-18 14:00:00', 'Pacific/Auckland');
+
+        $this->assertSame(
+            '15:13 Pacific/Auckland',
             $factory->createFromFormat('Y-m-d H:i:s', '2025-09-18 15:13:00')->format('H:i e'),
         );
     }


### PR DESCRIPTION
Changing plan because:
- the breaking change would be only for `createFromFormat` and only for tests, while a breaking change is dangerous when affecting production, `setTestNow` is explicitly marked as a test-only method, so the breaking change is not a danger, but only an annoyance, and an annoyance that would be hopefully for the better so users might discover they have tests that represent unrealistic cases (in the sense that tests using `setTestNow` and `createFromFormat` will not behave like in real life)
- `withTestNow` would have also require an alternative for default timezone
- too many methods/options will just add confusion