### PR TITLE
Add plus() and minus() methods

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -3333,6 +3333,11 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable, DiffOptio
     public function minimum($date = null);
 
     /**
+     * Subtract given amount of time to the current date.
+     */
+    public function minus(int $years = 0, int $months = 0, int $weeks = 0, int $days = 0, int $hours = 0, int $minutes = 0, int $seconds = 0, int $microseconds = 0): static;
+
+    /**
      * Mix another object into the class.
      *
      * @example
@@ -3506,6 +3511,11 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable, DiffOptio
      * Returns standardized plural of a given singular/plural unit name (in English).
      */
     public static function pluralUnit(string $unit): string;
+
+    /**
+     * Add given amount of time to the current date.
+     */
+    public function plus(int $years = 0, int $months = 0, int $weeks = 0, int $days = 0, int $hours = 0, int $minutes = 0, int $seconds = 0, int $microseconds = 0): static;
 
     /**
      * Modify to the previous occurrence of a given modifier such as a day of

--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -503,6 +503,48 @@ trait Units
         return $this->sub($unit, $value, $overflow, $anchorDay);
     }
 
+    /**
+     * Add given amount of time to the current date.
+     */
+    public function plus(
+        int $years = 0,
+        int $months = 0,
+        int $weeks = 0,
+        int $days = 0,
+        int $hours = 0,
+        int $minutes = 0,
+        int $seconds = 0,
+        int $microseconds = 0,
+    ): static {
+        return $this->addUnit(Unit::Year, $years)
+            ->addUnit(Unit::Month, $months)
+            ->add("
+                $weeks weeks $days days
+                $hours hours $minutes minutes $seconds seconds $microseconds microseconds
+            ");
+    }
+
+    /**
+     * Subtract given amount of time to the current date.
+     */
+    public function minus(
+        int $years = 0,
+        int $months = 0,
+        int $weeks = 0,
+        int $days = 0,
+        int $hours = 0,
+        int $minutes = 0,
+        int $seconds = 0,
+        int $microseconds = 0,
+    ): static {
+        return $this->subUnit(Unit::Year, $years)
+            ->subUnit(Unit::Month, $months)
+            ->sub("
+                $weeks weeks $days days
+                $hours hours $minutes minutes $seconds seconds $microseconds microseconds
+            ");
+    }
+
     private static function rawAddUnit(self $date, string $unit, int|float $value): ?static
     {
         try {

--- a/tests/CarbonImmutable/AddTest.php
+++ b/tests/CarbonImmutable/AddTest.php
@@ -474,4 +474,23 @@ class AddTest extends AbstractTestCase
         $this->assertTrue(Carbon::shouldOverflowYears());
         $this->assertCarbon(Carbon::createFromDate(2016, 2, 29)->addYears(2), 2018, 3, 1);
     }
+
+    public function testPlusMethod()
+    {
+        $this->assertSame(
+            '2028-08-14',
+            Carbon::create('2026-08-12')->plus(years: 2, hours: 48)->format('Y-m-d'),
+        );
+    }
+
+    public function testMinusMethod()
+    {
+        $this->assertSame(
+            '2026-08-11 18:00',
+            Carbon::create('2026-08-12')->minus(
+                hours: 6,
+                // days: 0.25, // Support for floating numbers planned for a later version
+            )->format('Y-m-d H:i'),
+        );
+    }
 }


### PR DESCRIPTION
Reimplement `plus()` and `minus()` methods without `$overflow` so it can be compatible with Laravel 12.