### PR TITLE
fix: abs(): Argument #1 ($num) must be of type int|float, string given

### DIFF
--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -161,7 +161,7 @@ trait Units
 
         $seconds = (int) $value;
         $microseconds = (int) round(
-            (abs($value) - abs($seconds)) * ($value < 0 ? -1 : 1) * static::MICROSECONDS_PER_SECOND,
+            (abs((float) $value) - abs($seconds)) * ($value < 0 ? -1 : 1) * static::MICROSECONDS_PER_SECOND,
         );
         $date = $this->setTimestamp($this->getTimestamp() + $seconds);
 


### PR DESCRIPTION
php8.2 if $value is string number, ex: '1.1' then will throw an error: `abs(): Argument #1 ($num) must be of type int|float, string given...` so convert float before abs

Fix #137