### PR TITLE
Prioritize day names over month names when translating string before the first number occurs in the string

### DIFF
--- a/src/Carbon/Lang/es.php
+++ b/src/Carbon/Lang/es.php
@@ -103,7 +103,7 @@ return [
         'sameElse' => 'L',
     ],
     'months' => ['enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre'],
-    'months_short' => ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'],
+    'months_short' => ['ene.', 'feb.', 'mar.', 'abr.', 'may.', 'jun.', 'jul.', 'ago.', 'sep.', 'oct.', 'nov.', 'dic.'],
     'mmm_suffix' => '.',
     'ordinal' => ':numberº',
     'weekdays' => ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'],

--- a/src/Carbon/Lang/es.php
+++ b/src/Carbon/Lang/es.php
@@ -104,7 +104,6 @@ return [
     ],
     'months' => ['enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre'],
     'months_short' => ['ene.', 'feb.', 'mar.', 'abr.', 'may.', 'jun.', 'jul.', 'ago.', 'sep.', 'oct.', 'nov.', 'dic.'],
-    'mmm_suffix' => '.',
     'ordinal' => ':numberº',
     'weekdays' => ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'],
     'weekdays_short' => ['dom.', 'lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.'],

--- a/src/Carbon/Lang/fy.php
+++ b/src/Carbon/Lang/fy.php
@@ -65,8 +65,7 @@ return [
         return $number.(($number === 1 || $number === 8 || $number >= 20) ? 'ste' : 'de');
     },
     'months' => ['jannewaris', 'febrewaris', 'maart', 'april', 'maaie', 'juny', 'july', 'augustus', 'septimber', 'oktober', 'novimber', 'desimber'],
-    'months_short' => ['jan', 'feb', 'mrt', 'apr', 'mai', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'des'],
-    'mmm_suffix' => '.',
+    'months_short' => ['jan.', 'feb.', 'mrt.', 'apr.', 'mai.', 'jun.', 'jul.', 'aug.', 'sep.', 'okt.', 'nov.', 'des.'],
     'weekdays' => ['snein', 'moandei', 'tiisdei', 'woansdei', 'tongersdei', 'freed', 'sneon'],
     'weekdays_short' => ['si.', 'mo.', 'ti.', 'wo.', 'to.', 'fr.', 'so.'],
     'weekdays_min' => ['Si', 'Mo', 'Ti', 'Wo', 'To', 'Fr', 'So'],

--- a/src/Carbon/Lang/nl.php
+++ b/src/Carbon/Lang/nl.php
@@ -101,8 +101,7 @@ return [
         return $number.(($number === 1 || $number === 8 || $number >= 20) ? 'ste' : 'de');
     },
     'months' => ['januari', 'februari', 'maart', 'april', 'mei', 'juni', 'juli', 'augustus', 'september', 'oktober', 'november', 'december'],
-    'months_short' => ['jan', 'feb', 'mrt', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec'],
-    'mmm_suffix' => '.',
+    'months_short' => ['jan.', 'feb.', 'mrt.', 'apr.', 'mei', 'jun.', 'jul.', 'aug.', 'sep.', 'okt.', 'nov.', 'dec.'],
     'weekdays' => ['zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag'],
     'weekdays_short' => ['zo.', 'ma.', 'di.', 'wo.', 'do.', 'vr.', 'za.'],
     'weekdays_min' => ['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -236,7 +236,9 @@ trait Creator
         ?string $locale = null,
         DateTimeZone|string|int|null $timezone = null,
     ): static {
-        return static::rawParse(static::translateTimeString($time, $locale, static::DEFAULT_LOCALE), $timezone);
+        $text = static::translateTimeString($time, $locale, static::DEFAULT_LOCALE);
+
+        return static::rawParse(str_replace("'", '', $text), $timezone);
     }
 
     /**

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -2127,15 +2127,9 @@ trait Date
             'SSSSSSSSS' => static fn (CarbonInterface $date) => self::floorZeroPad($date->micro * 1000, 9),
             'M' => 'month',
             'MM' => ['rawFormat', ['m']],
-            'MMM' => static function (CarbonInterface $date, $originalFormat = null) {
-                $month = $date->getTranslatedShortMonthName($originalFormat);
-                $suffix = $date->getTranslationMessage('mmm_suffix');
-                if ($suffix && $month !== $date->monthName) {
-                    $month .= $suffix;
-                }
-
-                return $month;
-            },
+            'MMM' => static fn (CarbonInterface $date, $originalFormat = null) => $date->getTranslatedShortMonthName(
+                $originalFormat,
+            ),
             'MMMM' => static fn (CarbonInterface $date, $originalFormat = null) => $date->getTranslatedMonthName(
                 $originalFormat,
             ),

--- a/src/Carbon/Traits/Localization.php
+++ b/src/Carbon/Traits/Localization.php
@@ -291,13 +291,17 @@ trait Localization
                 }
             }
 
-            $$translationKey = array_merge(
+            $monthTranslations = array_merge(
                 $mode & CarbonInterface::TRANSLATE_MONTHS
                     ? $processList(self::getTranslationArray($months, static::MONTHS_PER_YEAR, $timeString))
                     : [],
                 $mode & CarbonInterface::TRANSLATE_MONTHS
                     ? $processList(self::getTranslationArray($messages['months_short'] ?? [], static::MONTHS_PER_YEAR, $timeString))
                     : [],
+            );
+
+            $$translationKey = array_merge(
+                $monthTranslations,
                 $mode & CarbonInterface::TRANSLATE_DAYS
                     ? $processList(self::getTranslationArray($weekdays, static::DAYS_PER_WEEK, $timeString))
                     : [],
@@ -338,24 +342,50 @@ trait Localization
             ]),
             $fromTranslations,
         );
+        $monthNameCount = \count($monthTranslations);
+        $firstNumberOffset = preg_match('/^\D+\d/', $timeString, $match)
+            ? \strlen($match[0]) // -1 to remove the first digit, +1 to add the extra wrapping spaced added just below
+            : INF;
 
-        return substr(preg_replace_callback('/(?<=[\d\s+.\/,_-])('.implode('|', $fromTranslations).')(?=[\d\s+.\/,_-])/iu', function ($match) use ($fromTranslations, $toTranslations) {
-            [$chunk] = $match;
+        return substr(preg_replace_callback(
+            '/(?<=[\d\s+.\/,_-])('.implode('|', $fromTranslations).')(?=[\d\s+.\/,_-])/iu',
+            function ($match) use ($fromTranslations, $toTranslations, $monthNameCount, $firstNumberOffset) {
+                [[$chunk, $offset]] = $match;
 
-            $index = array_search($chunk, $fromTranslations);
+                $indexes = self::getMatchingWordIndexes($fromTranslations, $chunk);
 
-            if ($index !== false) {
-                return $toTranslations[$index] ?? '';
-            }
+                if ($indexes !== []) {
+                    // Before the first number in the string, prefer day names over month names
+                    $bestIndexes = \count($indexes) > 1 && $offset < $firstNumberOffset
+                        ? array_values(array_filter($indexes, static fn ($index) => $index > $monthNameCount))
+                        : [];
+                    $index = $bestIndexes[0] ?? $indexes[0];
 
-            foreach ($fromTranslations as $index => $word) {
-                if (preg_match("/^$word\$/iu", $chunk)) {
                     return $toTranslations[$index] ?? '';
                 }
-            }
 
-            return $chunk; // @codeCoverageIgnore
-        }, " $timeString "), 1, -1);
+                return $chunk; // @codeCoverageIgnore
+            },
+            " $timeString ",
+            flags: PREG_OFFSET_CAPTURE,
+        ), 1, -1);
+    }
+
+    private static function getMatchingWordIndexes(array $fromTranslations, string $search): array
+    {
+        $indexes = array_keys($fromTranslations, $search, true);
+
+        if ($indexes !== []) {
+            return $indexes;
+        }
+
+        foreach ($fromTranslations as $index => $word) {
+            if (preg_match("/^$word\$/iu", $search)) {
+                $indexes[] = $index;
+            }
+        }
+
+        return $indexes;
     }
 
     /**

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -317,6 +317,7 @@ class TestingAidsTest extends AbstractTestCase
     {
         Carbon::setTestNow(null);
         $n1 = Carbon::now();
+        usleep(1);
         $n2 = Carbon::now();
 
         $this->assertTrue($n2 > $n1);

--- a/tests/CarbonImmutable/CreateTest.php
+++ b/tests/CarbonImmutable/CreateTest.php
@@ -242,6 +242,17 @@ class CreateTest extends AbstractTestCase
         $this->assertSame('2021-01-27 00:00:00', $date->format('Y-m-d H:i:s'));
     }
 
+    public function testParseFromLocaleWithDayNameAndMonthName()
+    {
+        $date = Carbon::parseFromLocale('mar 4 ago \'26 00:00', 'es');
+
+        $this->assertSame('2026-08-04 00:00:00', $date->format('Y-m-d H:i:s'));
+
+        $date = Carbon::parseFromLocale('mar 21 avr 26 00:00', 'fr');
+
+        $this->assertSame('2026-04-21 00:00:00', $date->format('Y-m-d H:i:s'));
+    }
+
     public function testParseFromLocaleWithDefaultLocale()
     {
         Carbon::setLocale('fr');

--- a/tests/CarbonImmutable/LocalizationTest.php
+++ b/tests/CarbonImmutable/LocalizationTest.php
@@ -943,4 +943,24 @@ class LocalizationTest extends AbstractTestCase
             Carbon::translateTimeString("mié. 17 Jun '26 20:00", 'es', 'en'),
         );
     }
+
+    public function testTranslateCanGuessWhenMarIsNotAMonth()
+    {
+        $this->assertSame(
+            "Tue 4 Aug '26 00:00",
+            Carbon::translateTimeString('mar 4 ago \'26 00:00', 'es', 'en'),
+        );
+        $this->assertSame(
+            "Tue 4 Aug '26 00:00",
+            Carbon::translateTimeString('mar. 4 ago. \'26 00:00', 'es', 'en'),
+        );
+        $this->assertSame(
+            "Tue 21 Apr '26 00:00",
+            Carbon::translateTimeString('mar 21 avr \'26 00:00', 'fr', 'en'),
+        );
+        $this->assertSame(
+            "Tue 21 Apr '26 00:00",
+            Carbon::translateTimeString('mar. 21 avr. \'26 00:00', 'fr', 'en'),
+        );
+    }
 }


### PR DESCRIPTION
Fix #138