### PR TITLE
Quote non-token characters in matchFormatPattern

### DIFF
--- a/src/Carbon/Factory.php
+++ b/src/Carbon/Factory.php
@@ -815,20 +815,42 @@ class Factory
      */
     private function matchFormatPattern(string $date, string $format, array $replacements): bool
     {
+        // Null bytes would collide with the fragment sentinels used below.
+        $format = str_replace("\0", '', $format);
         // Preg quote, but remove escaped backslashes since we'll deal with escaped characters in the format string.
         $regex = str_replace('\\\\', '\\', $format);
-        // Replace not-escaped letters
+        // Replace not-escaped letters, wrapping each generated fragment between
+        // null-byte sentinels so the generic quoting below leaves them intact.
         $regex = preg_replace_callback(
             '/(?<!\\\\)((?:\\\\{2})*)(['.implode('', array_keys($replacements)).'])/',
-            static fn ($match) => $match[1].strtr($match[2], $replacements),
+            static fn ($match) => "\0{$match[1]}".strtr($match[2], $replacements)."\0",
             $regex,
         );
         // Replace escaped letters by the letter itself
         $regex = preg_replace('/(?<!\\\\)((?:\\\\{2})*)\\\\(\w)/', '$1$2', $regex);
-        // Escape not escaped slashes
-        $regex = preg_replace('#(?<!\\\\)((?:\\\\{2})*)/#', '$1\\/', $regex);
 
-        return (bool) @preg_match('/^'.$regex.'$/', $date);
+        $chunks = explode("\0", $regex);
+
+        foreach ($chunks as $index => &$chunk) {
+            if ($index % 2) {
+                continue;
+            }
+
+            // Quote every character that did not come from a format token:
+            // backslash escapes resolve to their quoted literal target, any
+            // other byte (including dangling backslashes) is quoted as-is.
+            $chunks[$index] = preg_replace_callback(
+                '/\\\\.|./s',
+                static fn ($match) => preg_quote(
+                    $match[0][0] === '\\' && isset($match[0][1]) ? $match[0][1] : $match[0],
+                    '/',
+                ),
+                $chunk,
+            );
+        }
+        unset($chunk);
+
+        return (bool) @preg_match('/^'.implode('', $chunks).'$/', $date);
     }
 
     private function setDefaultTimezone(string $timezone, ?DateTimeInterface $date = null): void

--- a/src/Carbon/Factory.php
+++ b/src/Carbon/Factory.php
@@ -823,7 +823,7 @@ class Factory
         // null-byte sentinels so the generic quoting below leaves them intact.
         $regex = preg_replace_callback(
             '/(?<!\\\\)((?:\\\\{2})*)(['.implode('', array_keys($replacements)).'])/',
-            static fn ($match) => "\0{$match[1]}".strtr($match[2], $replacements)."\0",
+            static fn ($match) => "\0".$match[1].strtr($match[2], $replacements)."\0",
             $regex,
         );
         // Replace escaped letters by the letter itself
@@ -831,7 +831,7 @@ class Factory
 
         $chunks = explode("\0", $regex);
 
-        foreach ($chunks as $index => &$chunk) {
+        foreach ($chunks as $index => $chunk) {
             if ($index % 2) {
                 continue;
             }
@@ -848,7 +848,6 @@ class Factory
                 $chunk,
             );
         }
-        unset($chunk);
 
         return (bool) @preg_match('/^'.implode('', $chunks).'$/', $date);
     }

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -1263,6 +1263,7 @@ class IsTest extends AbstractTestCase
         $this->assertTrue(Carbon::hasFormat('12/30/2019', 'm/d/Y'));
         $this->assertTrue(Carbon::hasFormat('30/12/2019', 'd/m/Y'));
         $this->assertTrue(Carbon::hasFormat('Sun 21st', 'D jS'));
+        $this->assertTrue(Carbon::hasFormat('1975{2}', 'Y{2}'));
 
         $this->assertTrue(Carbon::hasFormat('2000-07-01T00:00:00+00:00', Carbon::ATOM));
         $this->assertTrue(Carbon::hasFormat('Y-01-30\\', '\\Y-m-d\\\\'));
@@ -1304,6 +1305,7 @@ class IsTest extends AbstractTestCase
         $this->assertTrue(Carbon::hasFormatWithModifiers('1975-05-01', 'Y-m-d|'));
         $this->assertTrue(Carbon::hasFormatWithModifiers('1975-05-01', 'Y-*-d'));
         $this->assertTrue(Carbon::hasFormatWithModifiers('1975-05-01', 'Y-??-d!'));
+        $this->assertTrue(Carbon::hasFormatWithModifiers('1975{2}', 'Y{2}'));
         $this->assertTrue(Carbon::hasFormatWithModifiers('1975-05-01', 'Y#m#d'));
         $this->assertTrue(Carbon::hasFormatWithModifiers('1975/05/31', 'Y#m#d'));
 
@@ -1312,6 +1314,7 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::hasFormatWithModifiers('1975-05-01', 'Y-?-d|'));
         $this->assertFalse(Carbon::hasFormatWithModifiers('1975--01', 'Y-*-d'));
         $this->assertFalse(Carbon::hasFormatWithModifiers('1975705-01', 'Y#m#d'));
+        $this->assertFalse(Carbon::hasFormatWithModifiers('19751976', 'Y{2}'));
     }
 
     public static function dataForFormatLetters(): array


### PR DESCRIPTION
`hasFormatWithModifiers()` interpolated the format string into the final PCRE pattern without quoting it. Only format letters and modifiers were replaced; every other byte (parentheses, quantifiers, alternation, anchors) kept its regex meaning, so a caller-supplied format could alter the structure of the validation pattern rather than match literally:

```php
Carbon::hasFormatWithModifiers('kkkk', 'k{4}'); // true before this PR: '{4}' acted as a quantifier
Carbon::hasFormatWithModifiers('qqqq', 'q{4}'); // true before this PR
Carbon::hasFormat('qqqq', 'q{4}');              // false: the sibling API preg_quotes its input
```

The inconsistency with `hasFormat()` also meant the two validators disagreed on identical inputs.

## How it is fixed

`matchFormatPattern()` now wraps each token-generated regex fragment between null-byte sentinels during the substitution pass, then quotes every remaining byte of the pattern. Backslash escapes in the format (`\T`, `\.`) still resolve to their literal target, and token fragments (`d`, `#`, `*`, `?`, `!`, `|`, `+`) keep their regex meaning. Raw null bytes in the format are stripped before processing so they cannot collide with the sentinels.

Behavior change to be aware of: a format containing unescaped regex metacharacters that used to be interpreted as pattern syntax (e.g. `.*`, `(a|b)`) will now only match those characters literally. This matches what `hasFormat()` already did and what `createFromFormat()` escape semantics imply.