### PR TITLE
Prevent unintended injection of unsafe filters or non-date classes during period unserialization

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -21,6 +21,7 @@ use Carbon\Exceptions\InvalidPeriodDateException;
 use Carbon\Exceptions\InvalidPeriodParameterException;
 use Carbon\Exceptions\NotACarbonClassException;
 use Carbon\Exceptions\NotAPeriodException;
+use Carbon\Exceptions\PeriodFilterSafetyException;
 use Carbon\Exceptions\UnknownGetterException;
 use Carbon\Exceptions\UnknownMethodException;
 use Carbon\Exceptions\UnreachableException;
@@ -940,9 +941,7 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
      */
     public function setDateClass(string $dateClass)
     {
-        if (!is_a($dateClass, CarbonInterface::class, true)) {
-            throw new NotACarbonClassException($dateClass);
-        }
+        NotACarbonClassException::expectCarbonInterface($dateClass);
 
         $self = $this->copyIfImmutable();
         $self->dateClass = $dateClass;
@@ -2386,6 +2385,36 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
                 $data,
             );
 
+            if (isset($values['dateClass'])) {
+                NotACarbonClassException::expectCarbonInterface($values['dateClass']);
+            }
+
+            if (
+                isset($values['filters'])
+                // Non-array filters are not an issue as they will be rejected before being read with:
+                // Cannot assign X to property Carbon\CarbonPeriod::$filters of type array
+                && \is_array($values['filters'])
+                && PeriodFilterSafetyException::isDetectionEnabled()
+            ) {
+                foreach ($values['filters'] as $tuple) {
+                    if (\is_array($tuple[0])) {
+                        $subject = $tuple[0][0];
+
+                        if (
+                            is_a($subject, DatePeriod::class, true)
+                            || is_a($subject, DateInterval::class, true)
+                            || is_a($subject, DateTimeInterface::class, true)
+                        ) {
+                            continue;
+                        }
+
+                        throw new PeriodFilterSafetyException('filters not referring to date method');
+                    }
+
+                    throw new PeriodFilterSafetyException('custom filters');
+                }
+            }
+
             $this->initializeSerialization($values);
 
             foreach ($values as $key => $value) {
@@ -2443,7 +2472,11 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
             }
         } catch (Throwable $e) {
             // @codeCoverageIgnoreStart
-            if (!method_exists(parent::class, '__unserialize')) {
+            if (
+                $e instanceof PeriodFilterSafetyException
+                || $e instanceof NotACarbonClassException
+                || !method_exists(parent::class, '__unserialize')
+            ) {
                 throw $e;
             }
 

--- a/src/Carbon/Exceptions/NotACarbonClassException.php
+++ b/src/Carbon/Exceptions/NotACarbonClassException.php
@@ -14,11 +14,14 @@ declare(strict_types=1);
 namespace Carbon\Exceptions;
 
 use Carbon\CarbonInterface;
+use Carbon\Traits\TogglableDetection;
 use InvalidArgumentException as BaseInvalidArgumentException;
 use Throwable;
 
 class NotACarbonClassException extends BaseInvalidArgumentException implements InvalidArgumentException
 {
+    use TogglableDetection;
+
     /**
      * The className.
      *
@@ -37,11 +40,33 @@ class NotACarbonClassException extends BaseInvalidArgumentException implements I
     {
         $this->className = $className;
 
-        parent::__construct(\sprintf(
-            'Given class does not implement %s: %s',
-            CarbonInterface::class,
-            $className,
-        ), $code, $previous);
+        parent::__construct(
+            \sprintf(
+                'Given class does not implement %s: %s',
+                CarbonInterface::class,
+                $className,
+            )."\nBehavior can be unpredictable and unsecure ".
+            "(in particular if you are unserializing data from a source you can't fully trust)\n".
+            "But if you're sure you want to allow it use \$result = ".
+            'NotACarbonClassException::allow(static fn () => ...)',
+            $code,
+            $previous,
+        );
+    }
+
+    public static function expectCarbonInterface(mixed $className): void
+    {
+        if (!self::$detectionEnabled) {
+            return;
+        }
+
+        if (!\is_string($className)) {
+            throw new self(\gettype($className));
+        }
+
+        if (!is_a($className, CarbonInterface::class, true)) {
+            throw new self($className);
+        }
     }
 
     /**

--- a/src/Carbon/Exceptions/PeriodFilterSafetyException.php
+++ b/src/Carbon/Exceptions/PeriodFilterSafetyException.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon\Exceptions;
+
+use Carbon\Traits\TogglableDetection;
+use RuntimeException as BaseRuntimeException;
+use Throwable;
+
+final class PeriodFilterSafetyException extends BaseRuntimeException implements RuntimeException
+{
+    use TogglableDetection;
+
+    public function __construct(
+        public string $disallowedFilter,
+        int $code = 0,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct(
+            "For safety reason, unserializing CarbonPeriod objects with $disallowedFilter is disallowed.\n".
+            "If your serialized string is fully safe and you're sure you want to allow them, wrap the unseritalization".
+            ' into $result = PeriodFilterSafetyException::allow(static fn () => unserialize($data))',
+            $code,
+            $previous,
+        );
+    }
+}

--- a/src/Carbon/Traits/Serialization.php
+++ b/src/Carbon/Traits/Serialization.php
@@ -73,7 +73,18 @@ trait Serialization
     /**
      * Create an instance from a serialized string.
      *
-     * If $value is not from a trusted source, consider using the allowed_classes option to limit
+     * Unserializing object can lead to arbitrary execution of period filters, and assignation
+     * of unvalidated values to properties.
+     *
+     * You should never unserialize a value from not from a trusted source. Ensure you unserialize
+     * only strings coming from storage no unauthorized party can read nor write, prefer to exchange
+     * data with other systems via static formats such as JSON.
+     *
+     * If the data has to transit via untrusted systems before unserialization, then you should
+     * sign it cryptographically (with HMAC or OpenSSL for example), and verify the signature
+     * before unserializing it.
+     *
+     * If the content of $value is unknown, consider using the allowed_classes option to limit
      * the types of objects that can be built, for instance:
      *
      * @example

--- a/src/Carbon/Traits/TogglableDetection.php
+++ b/src/Carbon/Traits/TogglableDetection.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon\Traits;
+
+trait TogglableDetection
+{
+    private static bool $detectionEnabled = true;
+
+    public static function isDetectionEnabled(): bool
+    {
+        return self::$detectionEnabled;
+    }
+
+    public static function allow(callable $action): mixed
+    {
+        self::$detectionEnabled = false;
+
+        try {
+            return $action();
+        } finally {
+            self::$detectionEnabled = true;
+        }
+    }
+}

--- a/tests/Carbon/Exceptions/NotACarbonClassExceptionTest.php
+++ b/tests/Carbon/Exceptions/NotACarbonClassExceptionTest.php
@@ -22,7 +22,11 @@ class NotACarbonClassExceptionTest extends AbstractTestCase
 
         $this->assertSame($className, $exception->getClassName());
 
-        $this->assertSame('Given class does not implement Carbon\CarbonInterface: foo', $exception->getMessage());
+        $this->assertSame(implode("\n", [
+            'Given class does not implement Carbon\CarbonInterface: foo',
+            "Behavior can be unpredictable and unsecure (in particular if you are unserializing data from a source you can't fully trust)",
+            "But if you're sure you want to allow it use \$result = NotACarbonClassException::allow(static fn () => ...)",
+        ]), $exception->getMessage());
         $this->assertSame(0, $exception->getCode());
         $this->assertNull($exception->getPrevious());
     }

--- a/tests/CarbonPeriod/SerializationTest.php
+++ b/tests/CarbonPeriod/SerializationTest.php
@@ -15,6 +15,8 @@ use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
+use Carbon\Exceptions\NotACarbonClassException;
+use Carbon\Exceptions\PeriodFilterSafetyException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\AbstractTestCase;
 
@@ -217,6 +219,122 @@ class SerializationTest extends AbstractTestCase
         $this->assertNull($periodCopy->getEndDate());
         $this->assertSame(4, $periodCopy->getRecurrences());
         $this->assertIntervalDuration('1 week', $periodCopy->getDateInterval());
+    }
+
+    public function testFiltersSafetyProtectionOn(): void
+    {
+        $this->expectException(PeriodFilterSafetyException::class);
+        $this->expectExceptionMessage(
+            "For safety reason, unserializing CarbonPeriod objects with custom filters is disallowed.\n".
+            "If your serialized string is fully safe and you're sure you want to allow them, wrap the ".
+            'unseritalization into $result = PeriodFilterSafetyException::allow(static fn () => unserialize($data))',
+        );
+
+        $p = CarbonPeriod::create('2026-09-01', '2026-09-20');
+        $p->setFilters([
+            ['foo'],
+        ]);
+
+        unserialize(serialize($p));
+    }
+
+    public function testFiltersSafetyProtectionForNonDateObjects(): void
+    {
+        $this->expectException(PeriodFilterSafetyException::class);
+        $this->expectExceptionMessage(
+            "For safety reason, unserializing CarbonPeriod objects with filters not referring to date method is disallowed.\n".
+            "If your serialized string is fully safe and you're sure you want to allow them, wrap the ".
+            'unseritalization into $result = PeriodFilterSafetyException::allow(static fn () => unserialize($data))',
+        );
+
+        $p = CarbonPeriod::create('2026-09-01', '2026-09-20');
+        $p->setFilters([
+            [[PeriodFilterSafetyException::class, 'allow'], null],
+        ]);
+
+        unserialize(serialize($p));
+    }
+
+    public function testFiltersSafetyProtectionOff(): void
+    {
+        $filters = [
+            ['foo'],
+        ];
+        $p = CarbonPeriod::create('2026-09-01', '2026-09-20');
+        $p->setFilters($filters);
+        $string = serialize($p);
+
+        $p2 = PeriodFilterSafetyException::allow(static fn () => unserialize($string));
+
+        $this->assertSame($filters, $p2->getFilters());
+    }
+
+    public function testFiltersSafetyProtectionOnlyAffectFilters(): void
+    {
+        $this->expectException(NotACarbonClassException::class);
+        $this->expectExceptionMessage(
+            "Given class does not implement Carbon\\CarbonInterface: DateTime\n".
+            "Behavior can be unpredictable and unsecure (in particular if you are unserializing data from a source you can't fully trust)\n".
+            "But if you're sure you want to allow it use \$result = NotACarbonClassException::allow(static fn () => ...)",
+        );
+
+        $p = CarbonPeriod::create('2026-09-01', '2026-09-20');
+        NotACarbonClassException::allow(static function () use ($p) {
+            $p->setDateClass(DateTime::class);
+        });
+        $string = serialize($p);
+
+        $p2 = PeriodFilterSafetyException::allow(static fn () => unserialize($string));
+
+        $this->assertSame([], $p2->getFilters());
+    }
+
+    public function testNotACarbonClassExceptionOn(): void
+    {
+        $this->expectException(NotACarbonClassException::class);
+        $this->expectExceptionMessage(
+            "Given class does not implement Carbon\\CarbonInterface: DateTime\n".
+            "Behavior can be unpredictable and unsecure (in particular if you are unserializing data from a source you can't fully trust)\n".
+            "But if you're sure you want to allow it use \$result = NotACarbonClassException::allow(static fn () => ...)",
+        );
+
+        $p = CarbonPeriod::create('2026-09-01', '2026-09-20');
+        NotACarbonClassException::allow(static function () use ($p) {
+            $p->setDateClass(DateTime::class);
+        });
+
+        unserialize(serialize($p));
+    }
+
+    public function testNotACarbonClassExceptionOff(): void
+    {
+        $p = CarbonPeriod::create('2026-09-01', '2026-09-20');
+        NotACarbonClassException::allow(static function () use ($p) {
+            $p->setDateClass(DateTime::class);
+        });
+        $string = serialize($p);
+
+        $p2 = NotACarbonClassException::allow(static fn () => unserialize($string));
+
+        $this->assertSame(DateTime::class, $p2->getDateClass());
+    }
+
+    public function testNotACarbonClassExceptionForNonStringValue(): void
+    {
+        $this->expectException(NotACarbonClassException::class);
+        $this->expectExceptionMessage(
+            "Given class does not implement Carbon\\CarbonInterface: integer\n".
+            "Behavior can be unpredictable and unsecure (in particular if you are unserializing data from a source you can't fully trust)\n".
+            "But if you're sure you want to allow it use \$result = NotACarbonClassException::allow(static fn () => ...)",
+        );
+
+        $p = CarbonPeriod::create('2026-09-01', '2026-09-20');
+        NotACarbonClassException::allow(static function () use ($p) {
+            $p->setDateClass(DateTime::class);
+        });
+        $string = str_replace('s:8:"DateTime"', 'i:0', serialize($p));
+
+        unserialize($string);
     }
 
     private function assertIntervalDuration(string $duration, mixed $interval): void


### PR DESCRIPTION
⚠️ Breaking change: now by default, when unserializing `CarbonPeriod` objects, an error is thrown if the data contain custom filters calling arbitrary functions or non-date object methods, an error is also throw if it contains a dataClass that does not implement `CarbonInterface`.

This breaking change is exceptionally introduced in a minor version because of the unlikeliness of this behavior to be intended and with security implications weighted carefully.

- Cases where such values are used for dateClass and filters should be extremely rare
- If this exception occurs to you and you didn't set purposely custom filters or special dateClass, then it could mean that you are unserializing strings that have been maliciously altered
- If you purposely use those features with serialization, sorry for the inconvenience, use the tools below:

`NotACarbonClassException::allow()` and `PeriodFilterSafetyException::allow()` allow to skip those new safety measures. If those exceptions are happening while unserializing data coming from (or through) an untrusted source, then don't toggle them and instead, sign the payload with HMAC or OpenSSL when you serialize it and verify this signature before unserializing. If you're taking this path, verify your cryptographic design is solid (payload entirely signed/verified, private key only know by trusted parties as those would be allowed to execute arbitrary functions on your system).

Credit to @iliaal for the finding.